### PR TITLE
CORE-3193 Fixed: Duplicated images on iOS 13

### DIFF
--- a/UIImageViewAligned.swift
+++ b/UIImageViewAligned.swift
@@ -236,11 +236,14 @@ open class UIImageViewAligned: UIImageView {
         }
         
         realImageView?.frame = realFrame.integral
-        
+
         // Make sure we clear the contents of this container layer, since it refreshes from the image property once in a while.
-        layer.contents = nil
-        if #available(iOS 11, *) {
+        if #available(iOS 13, *) {
+            self.layer.contents = CALayer()
+        } else if #available(iOS 11, *) {
             super.image = nil
+        } else {
+            layer.contents = nil
         }
     }
     

--- a/UIImageViewAligned.swift
+++ b/UIImageViewAligned.swift
@@ -202,10 +202,15 @@ open class UIImageViewAligned: UIImageView {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         layer.contents = nil
-        if #available(iOS 11, *) {
+
+        if #available(iOS 13, *) {
+            self.layer.contents = CALayer()
+        } else if #available(iOS 11, *) {
             let currentImage = realImageView?.image
             image = nil
             realImageView?.image = currentImage
+        } else {
+            layer.contents = nil
         }
     }
     


### PR DESCRIPTION
**What I did:**
Forked this repo
Fixed duplicated images on iOS 13

Before:
![IMG_7844](https://user-images.githubusercontent.com/8472089/67294464-3dd66300-f4bc-11e9-9184-79c711db6e3f.PNG)

Now: 
![IMG_7866](https://user-images.githubusercontent.com/8472089/67296569-03ba9080-f4bf-11e9-9110-b1e45b1913bc.PNG)

